### PR TITLE
Network trigger

### DIFF
--- a/install-files/usr/lib/NetworkManager/dispatcher.d/01-lliurex-autotags-network
+++ b/install-files/usr/lib/NetworkManager/dispatcher.d/01-lliurex-autotags-network
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+case "$2" in
+    up)
+        /usr/sbin/lliurex-autotags-network
+    ;;
+
+    down)
+        /usr/sbin/lliurex-autotags-network
+    ;;
+
+    *)
+    ;;
+esac

--- a/install-files/usr/lib/NetworkManager/dispatcher.d/zz-lliurex-autotags-network
+++ b/install-files/usr/lib/NetworkManager/dispatcher.d/zz-lliurex-autotags-network
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 case "$2" in
+    dhcp4-change)
+        /usr/sbin/lliurex-autotags-network
+    ;;
+
     up)
         /usr/sbin/lliurex-autotags-network
     ;;

--- a/install-files/usr/sbin/lliurex-autotags-network
+++ b/install-files/usr/sbin/lliurex-autotags-network
@@ -12,6 +12,7 @@ import glob
 import subprocess
 import pathlib
 import fcntl
+import ipaddress
 
 LOCK_FILE = "/var/run/lliurex-autotags-network.lock"
 
@@ -48,6 +49,7 @@ if __name__=="__main__":
 		ifaces = edupals.network.Interface.interfaces()
 
 		for iface in ifaces:
+
 			addresses = iface.addresses()
 
 			ntype = iface.get_type()
@@ -62,8 +64,9 @@ if __name__=="__main__":
 					tags.append("network.mac.{0:02x}{1:02x}{2:02x}{3:02x}{4:02x}{5:02x}".format(mac.address[0],mac.address[1],mac.address[2],mac.address[3],mac.address[4],mac.address[5]))
 
 				if (address.family == SYS_ADDRESS_FAMILY_IP4):
-					ip4 = address.address
-					tags.append("network.ipv4.{0}.{1}.{2}.0".format(ip4.packed[0],ip4.packed[1],ip4.packed[2]))
+					ip4 = edupals.network.get_network_ip(str(address.address),str(address.netmask))
+
+					tags.append("network.ipv4.{0}.{1}.{2}.{3}".format(ip4.packed[0],ip4.packed[1],ip4.packed[2],ip4.packed[3]))
 
 		release(lock_fd)
 

--- a/install-files/usr/sbin/lliurex-autotags-network
+++ b/install-files/usr/sbin/lliurex-autotags-network
@@ -11,6 +11,9 @@ import sys
 import glob
 import subprocess
 import pathlib
+import fcntl
+
+LOCK_FILE = "/var/run/lliurex-autotags-network.lock"
 
 TAGS_DIR = "/etc/lliurex-auto-upgrade/tags/"
 tags = []
@@ -23,12 +26,23 @@ def clear_tags():
 	for path in (glob.glob(TAGS_DIR+"network.*")):
 		os.remove(path)
 
+def lock():
+	fd = os.open(LOCK_FILE, os.O_RDWR | os.O_CREAT)
+	fcntl.flock(fd, fcntl.LOCK_EX)
+
+	return fd
+
+def release(fd):
+	fcntl.flock(fd, fcntl.LOCK_UN)
+	os.close(fd)
+
 if __name__=="__main__":
 
 	if (not os.path.exists(TAGS_DIR)):
 		sys.exit(0)
 
 	try:
+		lock_fd = lock()
 		clear_tags()
 
 		ifaces = edupals.network.Interface.interfaces()
@@ -50,6 +64,8 @@ if __name__=="__main__":
 				if (address.family == SYS_ADDRESS_FAMILY_IP4):
 					ip4 = address.address
 					tags.append("network.ipv4.{0}.{1}.{2}.0".format(ip4.packed[0],ip4.packed[1],ip4.packed[2]))
+
+		release(lock_fd)
 
 	except Exception as e:
 		pass


### PR DESCRIPTION
* NetworkManager hook reloads network tags when an interface goes up/down
* ipv4 network is no longer hardcoded to C class, computed using netmask instead