### PR TITLE
Gva networks

### DIFF
--- a/install-files/usr/sbin/lliurex-autotags-network
+++ b/install-files/usr/sbin/lliurex-autotags-network
@@ -154,7 +154,8 @@ if __name__=="__main__":
 
 					tags.append("network.ipv4.{0}.{1}.{2}.{3}".format(ip4.packed[0],ip4.packed[1],ip4.packed[2],ip4.packed[3]))
 
-		tag_gva_networks()
+		if (edupals.network.get_default_gateway()):
+			tag_gva_networks()
 
 		release(lock_fd)
 

--- a/install-files/usr/sbin/lliurex-autotags-system
+++ b/install-files/usr/sbin/lliurex-autotags-system
@@ -9,10 +9,36 @@ import sys
 import glob
 import subprocess
 import pathlib
+import re
 
 TAGS_DIR = "/etc/lliurex-auto-upgrade/tags/"
 tags = []
 model = "unknown"
+
+def is_tpm2():
+	tpm = False
+	# main case: file tpm_version_major is available
+	tpm_file="/sys/class/tpm/tpm0/tpm_version_major"
+	if (os.path.exists(tpm_file)) :
+		f = open(tpm_file,"r")
+		vstring = f.read(1)
+		# check for integer value
+		if (re.search('^[0-9]*$', vstring)):
+			tpm_version=int(vstring)
+			if (tpm_version >= 2):
+				tpm = True
+		f.close()
+	else:
+		# alternative: search description for 'TPM 2' string
+		for tpm_file in [ "/sys/class/tpm/tpm0/device/firmware_node/description", "/sys/class/tpm/tpm0/device/description" ] :
+			if (os.path.exists(tpm_file)) :
+				f = open(tpm_file,"r")
+				vstring = f.readline()
+				# check for TPM 2 string
+				if (re.search('TPM 2', vstring)):
+					tpm = True
+				f.close()
+	return tpm
 
 def is_secure_boot():
 	sb = False
@@ -52,6 +78,9 @@ def tag_system():
 
 		if (is_secure_boot()):
 			tags.append("system.platform.firmware.uefi.secureboot")
+
+		if (is_tpm2()):
+			tags.append("system.platform.tpm2")
 
 		# this needs a rethink
 		#if (os.path.exists("/boot/efi/EFI/lliurex-21/shimx64.efi")):

--- a/install-files/usr/sbin/lliurex-autotags-system
+++ b/install-files/usr/sbin/lliurex-autotags-system
@@ -79,9 +79,6 @@ def tag_system():
 		if (is_secure_boot()):
 			tags.append("system.platform.firmware.uefi.secureboot")
 
-		if (is_tpm2()):
-			tags.append("system.platform.tpm2")
-
 		# this needs a rethink
 		#if (os.path.exists("/boot/efi/EFI/lliurex-21/shimx64.efi")):
 			#tags.append("system.platform.firmware.uefi.shim")
@@ -97,6 +94,10 @@ def tag_system():
 	for model in models:
 		tags.append("system.gva.model."+model)
 	tags.append("system.gva.format."+hwdb["format"])
+
+	if (is_tpm2()):
+		tags.append("system.platform.tpm2")
+
 
 
 if __name__=="__main__":


### PR DESCRIPTION
Changes:
- Avoid to Write 'network.no-gva' tag when no network gateway is available
- Added system.platform.tpm2 tag to lliurex-autotags-system
