### PR TITLE
autotags are now hosted at run dir instead of etc

### DIFF
--- a/install-files/usr/sbin/lliurex-autotags-network
+++ b/install-files/usr/sbin/lliurex-autotags-network
@@ -16,9 +16,11 @@ import fcntl
 import dns.resolver
 from ipaddress import IPv4Address, IPv4Network
 
-LOCK_FILE = "/var/run/lliurex-autotags-network.lock"
+LOCK_FILE = "/run/lliurex-autotags-network.lock"
 
 TAGS_DIR = "/etc/lliurex-auto-upgrade/tags/"
+RUN_TAGS_DIR = "/run/lliurex-auto-upgrade/tags/"
+
 tags = []
 
 SYS_IFACE_TYPE_LOOPBACK = 772
@@ -113,6 +115,9 @@ def clear_tags():
 	for path in (glob.glob(TAGS_DIR+"network.*")):
 		os.remove(path)
 
+	for path in (glob.glob(RUN_TAGS_DIR+"network.*")):
+		os.remove(path)
+
 def lock():
 	fd = os.open(LOCK_FILE, os.O_RDWR | os.O_CREAT)
 	fcntl.flock(fd, fcntl.LOCK_EX)
@@ -125,8 +130,9 @@ def release(fd):
 
 if __name__=="__main__":
 
-	if (not os.path.exists(TAGS_DIR)):
-		sys.exit(0)
+	if (not os.path.exists(RUN_TAGS_DIR)):
+		p = pathlib.Path(RUN_TAGS_DIR)
+		p.mkdir(parents = True)
 
 	try:
 		lock_fd = lock()
@@ -163,6 +169,6 @@ if __name__=="__main__":
 		pass
 
 	for tag in tags:
-		p = pathlib.Path(TAGS_DIR + tag)
+		p = pathlib.Path(RUN_TAGS_DIR + tag)
 		p.touch()
 

--- a/install-files/usr/sbin/lliurex-autotags-system
+++ b/install-files/usr/sbin/lliurex-autotags-system
@@ -12,6 +12,8 @@ import pathlib
 import re
 
 TAGS_DIR = "/etc/lliurex-auto-upgrade/tags/"
+RUN_TAGS_DIR = "/run/lliurex-auto-upgrade/tags/"
+
 tags = []
 model = "unknown"
 
@@ -72,6 +74,9 @@ def clear_tags():
 	for path in (glob.glob(TAGS_DIR+"system.*")):
 		os.remove(path)
 
+	for path in (glob.glob(RUN_TAGS_DIR+"system.*")):
+		os.remove(path)
+
 def tag_system():
 	if (os.path.exists("/sys/firmware/efi")):
 		tags.append("system.platform.firmware.uefi")
@@ -101,12 +106,13 @@ def tag_system():
 
 
 if __name__=="__main__":
-	if (not os.path.exists(TAGS_DIR)):
-		sys.exit(0)
+	if (not os.path.exists(RUN_TAGS_DIR)):
+		p = pathlib.Path(RUN_TAGS_DIR)
+		p.mkdir(parents = True)
 
 	clear_tags()
 	tag_system()
 
 	for tag in tags:
-		p = pathlib.Path(TAGS_DIR+tag)
+		p = pathlib.Path(RUN_TAGS_DIR+tag)
 		p.touch()

--- a/install-files/usr/sbin/lliurex-autotags-version
+++ b/install-files/usr/sbin/lliurex-autotags-version
@@ -11,16 +11,23 @@ import subprocess
 import pathlib
 
 TAGS_DIR = "/etc/lliurex-auto-upgrade/tags/"
+RUN_TAGS_DIR = "/run/lliurex-auto-upgrade/tags/"
+
 tags = []
 
 def clear_tags():
 	for path in (glob.glob(TAGS_DIR+"lliurex.version.*")):
 		os.remove(path)
 
+	for path in (glob.glob(RUN_TAGS_DIR+"lliurex.version.*")):
+		os.remove(path)
+
+
 if __name__=="__main__":
 
-	if (not os.path.exists(TAGS_DIR)):
-		sys.exit(0)
+	if (not os.path.exists(RUN_TAGS_DIR)):
+		p = pathlib.Path(RUN_TAGS_DIR)
+		p.mkdir(parents = True)
 
 	try:
 		clear_tags()
@@ -34,6 +41,6 @@ if __name__=="__main__":
 
 
 	for tag in tags:
-		p = pathlib.Path(TAGS_DIR + tag)
+		p = pathlib.Path(RUN_TAGS_DIR + tag)
 		p.touch()
 


### PR DESCRIPTION
* autotags are stored at /run
* etc tag dir is being cleaned up for backwards compatibility
